### PR TITLE
OPL-4148: preserve legacy BAP lineage on reissue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Legacy pre-0.3 metadata reissue now preserves validated `currentPath` and `previousPath` exactly for both Type 42 and BIP32/xprv backups instead of resetting advanced lineage through `newId()`. Reissue remains offline and key-preserving: only the BRC-100-aligned public `rootAddress`/`bapId` change. Malformed paths, impossible lineage transitions, and mismatched stored BAP IDs fail closed before any identity is imported.
+
 ## [0.3.4] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -368,6 +368,36 @@ bap.importIds(plain, false);
 const backup = bap.exportForBackup(label?, xprv?, mnemonic?);
 ```
 
+#### Reissuing a pre-0.3 backup
+
+Version 0.3 intentionally changed the public BAP ID calculation to the
+BRC-100-aligned `identity-0` derivation. A verified pre-0.3 identity export can
+be loaded and reissued without changing its private key material or rotation
+history:
+
+```typescript
+if (bap.isLegacyIdsExport(legacyIds)) {
+  const mapping = bap.recomputeLegacyIds(legacyIds);
+  const reissuedIds = bap.exportIds();
+
+  // mapping contains oldBapId -> newBapId for display or local bookkeeping.
+}
+```
+
+`recomputeLegacyIds` preserves the existing `rootPk` or `xprv` container and
+each identity's `rootPath`, `idSeed`, `previousPath`, and `currentPath` exactly.
+Only `rootAddress` and `bapId` are recalculated. It does not rotate a key,
+derive replacement private key material, convert one key container into
+another, publish anything on-chain, or rebind an external account.
+
+The method verifies that the stored legacy root address and BAP ID match the
+provided key, then checks canonical path syntax and a possible
+predecessor-to-current transition. Legacy backups did not sign
+`previousPath`/`currentPath`, so local validation cannot prove that an otherwise
+well-formed lineage was never substituted. Corroborating lineage with on-chain
+history is a separate application-level check and is not performed by this
+offline library method.
+
 #### Master-Level Crypto
 
 ```typescript

--- a/src/README.md
+++ b/src/README.md
@@ -25,6 +25,8 @@ class BAP {
   exportId(idKey: string, encrypted?: boolean): string | Identities
   importIds(identities: string | Identities, encrypted?: boolean): void
   importOldIds(idData: OldIdentity[]): void
+  isLegacyIdsExport(ids: string | Identities | OldIdentity[]): boolean
+  recomputeLegacyIds(ids: string | Identities | OldIdentity[]): LegacyIdRecompute[]
   exportForBackup(label?: string, xprv?: string, mnemonic?: string): Type42MasterBackup | Bip32MasterBackup
 
   // Master-level crypto
@@ -47,6 +49,12 @@ class BAP {
   getHdPublicKey(childPath?: string): string  // BIP32 only
 }
 ```
+
+`recomputeLegacyIds` is an offline metadata reissue for verified pre-0.3
+exports. It preserves the key container, `rootPath`, `idSeed`, `previousPath`,
+and `currentPath`; only the BRC-100-aligned public `rootAddress`/`bapId` change.
+It validates locally possible lineage transitions, but legacy lineage fields
+were not signed and therefore cannot be authenticated from the backup alone.
 
 ## MasterID Class
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   BAP_BITCOM_ADDRESS_HEX,
   BAP_SERVER,
   ENCRYPTION_PATH,
+  MAX_INT,
 } from "./constants";
 import type {
   Attestation,
@@ -30,7 +31,7 @@ import type {
   PathPrefix,
 } from "./interface";
 import { MasterID } from "./MasterID";
-import { deriveIdentity0Address, Utils } from "./utils";
+import { bapIdFromAddress, deriveIdentity0Address, Utils } from "./utils";
 
 const { toArray, toUTF8, toBase64, toHex } = BSVUtils;
 const { electrumEncrypt, electrumDecrypt } = ECIES;
@@ -41,8 +42,68 @@ type ParsedIdEntry = {
   bapId: string;
   rootPath: string;
   rootAddress: string;
+  currentPath: string;
+  previousPath: string;
   idSeed: string;
 };
+
+type ParsedIdsExport = {
+  entries: ParsedIdEntry[];
+  lastIdPath?: string;
+};
+
+type Bip32PathPart = {
+  hardened: boolean;
+  value: number;
+};
+
+const CANONICAL_UINT = /^(?:0|[1-9]\d*)$/;
+
+function requireNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Legacy entry has invalid ${field}`);
+  }
+  return value;
+}
+
+function parseBip32Path(path: string): Bip32PathPart[] | null {
+  const rawParts = path.split("/");
+  if (rawParts.length !== 7 || rawParts[0] !== "m") return null;
+
+  const parts: Bip32PathPart[] = [];
+  for (const rawPart of rawParts.slice(1)) {
+    const match = rawPart.match(/^((?:0|[1-9]\d*))('?)$/);
+    if (!match) return null;
+    const value = Number(match[1]);
+    if (!Number.isSafeInteger(value) || value > MAX_INT) return null;
+    parts.push({ value, hardened: match[2] === "'" });
+  }
+
+  if (
+    parts[0].value !== 424150 ||
+    !parts[0].hardened ||
+    parts[1].value !== 0 ||
+    !parts[1].hardened ||
+    parts[2].value !== 0 ||
+    !parts[2].hardened
+  ) {
+    return null;
+  }
+
+  return parts;
+}
+
+function isCanonicalBip32Cursor(path: string): boolean {
+  if (parseBip32Path(path)) return true;
+  const rawParts = path.split("/");
+  if (rawParts.length !== 4 || rawParts[0] !== "") return false;
+  return rawParts.slice(1).every((part) => {
+    const match = part.match(/^((?:0|[1-9]\d*))('?)$/);
+    if (!match) return false;
+    const value = Number(match[1]);
+    return Number.isSafeInteger(value) && value <= MAX_INT;
+  });
+}
 
 /** Backup format for Type 42 mode (rootPk-based) */
 export interface Type42MasterBackup {
@@ -154,14 +215,21 @@ export class BAP {
     if (this.#isType42) {
       if (!this.#masterPrivateKey)
         throw new Error("Master private key not initialized");
-      walletRoot = this.#masterPrivateKey.deriveChild(
-        this.#masterPrivateKey.toPublicKey(),
-        bapId.rootPath
-      );
+      let base = this.#masterPrivateKey;
+      if (bapId.idSeed) {
+        const seedHex = toHex(Hash.sha256(bapId.idSeed, "utf8"));
+        base = base.deriveChild(base.toPublicKey(), seedHex);
+      }
+      walletRoot = base.deriveChild(base.toPublicKey(), bapId.rootPath);
     } else {
       if (!this.#HDPrivateKey)
         throw new Error("HD private key not initialized");
-      walletRoot = this.#HDPrivateKey.derive(bapId.rootPath).privKey;
+      let baseHd = this.#HDPrivateKey;
+      if (bapId.idSeed) {
+        const seedHex = toHex(Hash.sha256(bapId.idSeed, "utf8"));
+        baseHd = baseHd.derive(Utils.getSigningPathFromHex(seedHex));
+      }
+      walletRoot = baseHd.derive(bapId.rootPath).privKey;
     }
 
     if (deriveIdentity0Address(walletRoot) !== bapId.rootAddress) {
@@ -204,59 +272,220 @@ export class BAP {
   /** Normalize an ids export (encrypted string, Identities object, or old array). */
   #parseIdsExport(
     idData: Identities | OldIdentity[] | string
-  ): ParsedIdEntry[] {
+  ): ParsedIdsExport {
     let parsed: unknown = idData;
     if (typeof parsed === "string") {
       parsed = JSON.parse(this.decrypt(parsed));
     }
-    const entries = Array.isArray(parsed)
-      ? (parsed as OldIdentity[])
-      : (parsed as Identities | undefined)?.ids;
+
+    const isOldArray = Array.isArray(parsed);
+    const entries = isOldArray
+      ? parsed
+      : (parsed as Partial<Identities> | null)?.ids;
     if (!Array.isArray(entries)) {
       throw new Error("Unrecognized identities format");
     }
-    return entries.map((entry) => ({
-      bapId:
-        ("bapId" in entry ? entry.bapId : (entry as OldIdentity).identityKey) ??
-        "",
-      rootPath: entry.rootPath,
-      rootAddress: entry.rootAddress,
-      idSeed: entry.idSeed ?? "",
-    }));
+
+    let lastIdPath: string | undefined;
+    if (!isOldArray) {
+      lastIdPath = requireNonEmptyString(
+        (parsed as Partial<Identities>).lastIdPath,
+        "lastIdPath"
+      );
+    }
+
+    return {
+      entries: entries.map((rawEntry) => {
+        if (!rawEntry || typeof rawEntry !== "object") {
+          throw new Error("Legacy entry must be an object");
+        }
+        const entry = rawEntry as Partial<Identity & OldIdentity>;
+        const bapId =
+          "bapId" in entry
+            ? entry.bapId
+            : (entry as Partial<OldIdentity>).identityKey;
+        const idSeed = entry.idSeed;
+        if (idSeed !== undefined && typeof idSeed !== "string") {
+          throw new Error("Legacy entry has invalid idSeed");
+        }
+        if (!isOldArray && idSeed === undefined) {
+          throw new Error("Legacy entry has invalid idSeed");
+        }
+
+        return {
+          bapId: requireNonEmptyString(bapId, "bapId"),
+          rootPath: requireNonEmptyString(entry.rootPath, "rootPath"),
+          rootAddress: requireNonEmptyString(entry.rootAddress, "rootAddress"),
+          currentPath: requireNonEmptyString(entry.currentPath, "currentPath"),
+          previousPath: requireNonEmptyString(
+            entry.previousPath,
+            "previousPath"
+          ),
+          // idSeed was optional only in the oldest array schema.
+          idSeed: idSeed ?? "",
+        };
+      }),
+      lastIdPath,
+    };
+  }
+
+  #validateType42Lineage(entry: ParsedIdEntry): void {
+    const rootMatch = entry.rootPath.match(/^bap:((?:0|[1-9]\d*))$/);
+    if (!rootMatch || !Number.isSafeInteger(Number(rootMatch[1]))) {
+      throw new Error("Legacy entry has invalid Type 42 rootPath");
+    }
+
+    if (entry.currentPath === entry.rootPath) {
+      if (entry.previousPath !== entry.rootPath) {
+        throw new Error("Legacy entry has an impossible Type 42 lineage");
+      }
+      return;
+    }
+
+    const identityIndex = rootMatch[1];
+    const numericRotationStart = BigInt(identityIndex) + 1n;
+    const parseRotation = (
+      path: string
+    ): { namespace: "numeric" | "scoped"; rotation: bigint } | null => {
+      if (CANONICAL_UINT.test(path) && path !== "0") {
+        return { namespace: "numeric", rotation: BigInt(path) };
+      }
+      const scoped = path.match(
+        new RegExp(`^bap:${identityIndex}:((?:0|[1-9]\\d*))$`)
+      );
+      if (!scoped || scoped[1] === "0") return null;
+      return { namespace: "scoped", rotation: BigInt(scoped[1]) };
+    };
+
+    const current = parseRotation(entry.currentPath);
+    if (!current) {
+      throw new Error("Legacy entry has invalid Type 42 currentPath");
+    }
+
+    if (entry.previousPath === entry.rootPath) {
+      // Before the scoped bap:N:R format, getNextPath("bap:N") stripped
+      // non-digits and incremented N, producing the bare string "N+1".
+      const expectedFirstRotation =
+        current.namespace === "numeric" ? numericRotationStart : 1n;
+      if (current.rotation !== expectedFirstRotation) {
+        throw new Error("Legacy entry has an impossible Type 42 lineage");
+      }
+      return;
+    }
+
+    const previous = parseRotation(entry.previousPath);
+    if (
+      !previous ||
+      previous.namespace !== current.namespace ||
+      (previous.namespace === "numeric" &&
+        previous.rotation < numericRotationStart) ||
+      current.rotation !== previous.rotation + 1n
+    ) {
+      throw new Error("Legacy entry has an impossible Type 42 lineage");
+    }
+  }
+
+  #validateBip32Lineage(entry: ParsedIdEntry): void {
+    const root = parseBip32Path(entry.rootPath);
+    const previous = parseBip32Path(entry.previousPath);
+    const current = parseBip32Path(entry.currentPath);
+    if (!root || !previous || !current) {
+      throw new Error("Legacy entry has an invalid BIP32 lineage path");
+    }
+
+    if (entry.currentPath === entry.rootPath) {
+      if (entry.previousPath !== entry.rootPath) {
+        throw new Error("Legacy entry has an impossible BIP32 lineage");
+      }
+      return;
+    }
+
+    const sameIdentityNamespace = (candidate: Bip32PathPart[]): boolean =>
+      root
+        .slice(0, 5)
+        .every(
+          (part, index) =>
+            part.value === candidate[index].value &&
+            part.hardened === candidate[index].hardened
+        ) && root[5].hardened === candidate[5].hardened;
+
+    if (
+      !sameIdentityNamespace(previous) ||
+      !sameIdentityNamespace(current) ||
+      previous[5].value < root[5].value ||
+      current[5].value !== previous[5].value + 1
+    ) {
+      throw new Error("Legacy entry has an impossible BIP32 lineage");
+    }
+  }
+
+  #validateLegacyEntry(entry: ParsedIdEntry): void {
+    if (this.#isType42) {
+      this.#validateType42Lineage(entry);
+    } else {
+      this.#validateBip32Lineage(entry);
+    }
+
+    if (
+      this.#legacyRootAddress(entry.rootPath, entry.idSeed) !==
+      entry.rootAddress
+    ) {
+      throw new Error("ID does not belong to this private key");
+    }
+    if (bapIdFromAddress(entry.rootAddress) !== entry.bapId) {
+      throw new Error("Legacy entry bapId does not match rootAddress");
+    }
+  }
+
+  #validateLegacyCursor(lastIdPath: string | undefined): void {
+    if (lastIdPath === undefined) return;
+    if (this.#isType42) {
+      if (!/^bap:(?:0|[1-9]\d*)$/.test(lastIdPath)) {
+        throw new Error("Legacy export has invalid Type 42 lastIdPath");
+      }
+      return;
+    }
+    if (!isCanonicalBip32Cursor(lastIdPath)) {
+      throw new Error("Legacy export has invalid BIP32 lastIdPath");
+    }
   }
 
   /**
    * Check whether an ids export was produced by bsv-bap <= 0.2.x with this
    * key: every entry's stored rootAddress must match the legacy derivation
-   * of its rootPath. Returns false for current-format exports and for
-   * exports that belong to a different key.
+   * of its rootPath, its bapId must match that address, and its lineage must
+   * be locally well-formed. Returns false for current-format exports, exports
+   * that belong to a different key, and malformed lineage metadata.
+   *
+   * currentPath/previousPath were not signed in the legacy backup format.
+   * Local validation can reject impossible transitions, but cannot prove the
+   * authenticity of an otherwise valid substituted transition.
    */
   isLegacyIdsExport(idData: Identities | OldIdentity[] | string): boolean {
-    let entries: ParsedIdEntry[];
     try {
-      entries = this.#parseIdsExport(idData);
+      const parsed = this.#parseIdsExport(idData);
+      this.#validateLegacyCursor(parsed.lastIdPath);
+      return (
+        parsed.entries.length > 0 &&
+        parsed.entries.every((entry) => {
+          this.#validateLegacyEntry(entry);
+          return true;
+        })
+      );
     } catch {
       return false;
     }
-    return (
-      entries.length > 0 &&
-      entries.every(
-        (entry) =>
-          entry.rootPath &&
-          entry.rootAddress &&
-          this.#legacyRootAddress(entry.rootPath, entry.idSeed) ===
-            entry.rootAddress
-      )
-    );
   }
 
   /**
    * Recompute identities from a legacy (<= 0.2.x) export under the current
    * BRC-100 identity-0 derivation. Each entry is verified against the
    * legacy formula first — proving the export belongs to this key — then
-   * re-derived at its original rootPath/idSeed. The underlying keys are
-   * unchanged; the bapIds are NEW. Callers must re-export (`exportIds`)
-   * and reissue the backup file; the legacy export is obsolete after this.
+   * re-derived at its original rootPath/idSeed. The key container, rootPath,
+   * idSeed, currentPath, and previousPath are unchanged byte-for-byte; only
+   * rootAddress/bapId adopt the current public derivation. No rotation or key
+   * conversion occurs. Callers must re-export (`exportIds`) and reissue the
+   * backup file; the legacy export is obsolete after this.
    *
    * @throws if any entry does not match the legacy derivation either
    * (wrong key or unrecognized format) — never silently accepts.
@@ -264,38 +493,77 @@ export class BAP {
   recomputeLegacyIds(
     idData: Identities | OldIdentity[] | string
   ): LegacyIdRecompute[] {
-    const entries = this.#parseIdsExport(idData);
-    const recomputed: LegacyIdRecompute[] = [];
+    const parsed = this.#parseIdsExport(idData);
+    if (parsed.entries.length === 0) {
+      throw new Error("Legacy export contains no identities");
+    }
+    this.#validateLegacyCursor(parsed.lastIdPath);
+    for (const entry of parsed.entries) this.#validateLegacyEntry(entry);
 
-    for (const entry of entries) {
-      if (!entry.rootPath) {
-        throw new Error("Legacy entry is missing rootPath; cannot recompute");
-      }
-      if (
-        this.#legacyRootAddress(entry.rootPath, entry.idSeed) !==
-        entry.rootAddress
-      ) {
-        throw new Error("ID does not belong to this private key");
+    const staged = parsed.entries.map((entry) => {
+      let identity: MasterID;
+      if (this.#isType42) {
+        if (!this.#masterPrivateKey)
+          throw new Error("Type 42 parameters not initialized");
+        identity = new MasterID(
+          { rootPk: this.#masterPrivateKey },
+          entry.idSeed
+        );
+      } else {
+        if (!this.#HDPrivateKey)
+          throw new Error("HD private key not initialized");
+        identity = new MasterID(this.#HDPrivateKey, entry.idSeed);
       }
 
-      const identity = this.newId(entry.rootPath, entry.idSeed);
-      recomputed.push({
-        oldBapId: entry.bapId,
-        newBapId: identity.bapId,
+      identity.rootPath = entry.rootPath;
+      const newBapId = identity.bapId;
+      const newRootAddress = identity.rootAddress;
+      identity.import({
+        bapId: newBapId,
         rootPath: entry.rootPath,
+        rootAddress: newRootAddress,
+        currentPath: entry.currentPath,
+        previousPath: entry.previousPath,
+        idSeed: entry.idSeed,
+        lastIdPath: "",
       });
+
+      return {
+        identity,
+        mapping: {
+          oldBapId: entry.bapId,
+          newBapId,
+          rootPath: entry.rootPath,
+        } satisfies LegacyIdRecompute,
+      };
+    });
+
+    const stagedIds = new Set<string>();
+    for (const { identity } of staged) {
+      if (stagedIds.has(identity.bapId) || this.#ids[identity.bapId]) {
+        throw new Error("Legacy export contains a duplicate identity");
+      }
+      stagedIds.add(identity.bapId);
+    }
+
+    for (const { identity } of staged) {
+      this.#ids[identity.bapId] = identity;
 
       // Keep the Type 42 counter monotonic so a later argument-less newId()
       // cannot collide with a recomputed bap:N identity.
-      if (this.#isType42 && entry.rootPath.startsWith("bap:")) {
-        const counter = Number.parseInt(entry.rootPath.split(":")[1], 10);
-        if (!Number.isNaN(counter)) {
-          this.#identityCounter = Math.max(this.#identityCounter, counter + 1);
-        }
+      if (this.#isType42) {
+        const counter = Number(identity.rootPath.split(":")[1]);
+        this.#identityCounter = Math.max(this.#identityCounter, counter + 1);
       }
     }
 
-    return recomputed;
+    // Old array exports predate the container cursor. Preserve a real cursor
+    // when one exists; otherwise retain the prior behavior of using the final
+    // identity's root path for subsequent identity creation.
+    this.#lastIdPath =
+      parsed.lastIdPath ?? staged[staged.length - 1].identity.rootPath;
+
+    return staged.map(({ mapping }) => mapping);
   }
 
   listIds(): string[] {
@@ -686,7 +954,6 @@ export class BAP {
 }
 
 export { MasterID };
-export { bapIdFromAddress, bapIdFromPubkey } from "./utils";
 // Protocol prefixes (Bitcom addresses) re-exported for consumer convenience —
 // e.g. building AIP signatures or BAP transactions.
 export {
@@ -695,6 +962,7 @@ export {
   BAP_BITCOM_ADDRESS,
   BAP_BITCOM_ADDRESS_HEX,
 } from "./constants";
+export { bapIdFromAddress, bapIdFromPubkey } from "./utils";
 export type {
   Attestation,
   BapAccountBackup,

--- a/tests/legacy-recompute.test.ts
+++ b/tests/legacy-recompute.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, test } from "bun:test";
 import { Utils as BSVUtils, Hash, HD, Mnemonic, PrivateKey } from "@bsv/sdk";
 import { BAP } from "../src/index";
-import { bapIdFromAddress } from "../src/utils";
+import { bapIdFromAddress, deriveIdentity0Address, Utils } from "../src/utils";
 
 const ROOT_PATH = "bap:0";
 
@@ -32,17 +32,57 @@ function legacyType42Address(
     .toAddress();
 }
 
-function makeLegacyType42Entry(pk: PrivateKey, idSeed = "") {
-  const rootAddress = legacyType42Address(pk, ROOT_PATH, idSeed);
+function makeLegacyType42Entry(
+  pk: PrivateKey,
+  idSeed = "",
+  paths: {
+    rootPath?: string;
+    currentPath?: string;
+    previousPath?: string;
+  } = {}
+) {
+  const rootPath = paths.rootPath ?? ROOT_PATH;
+  const rootAddress = legacyType42Address(pk, rootPath, idSeed);
   return {
     bapId: bapIdFromAddress(rootAddress),
-    rootPath: ROOT_PATH,
+    rootPath,
     rootAddress,
-    currentPath: ROOT_PATH,
-    previousPath: ROOT_PATH,
+    currentPath: paths.currentPath ?? rootPath,
+    previousPath: paths.previousPath ?? rootPath,
     idSeed,
     lastIdPath: "",
   };
+}
+
+function legacyHdAddress(hd: HD, rootPath: string, idSeed = ""): string {
+  let base = hd;
+  if (idSeed) {
+    const seedHex = BSVUtils.toHex(Hash.sha256(idSeed, "utf8"));
+    base = base.derive(Utils.getSigningPathFromHex(seedHex));
+  }
+  return base.derive(rootPath).pubKey.toAddress();
+}
+
+function hdAccountKey(hd: HD, rootPath: string, idSeed = ""): PrivateKey {
+  let base = hd;
+  if (idSeed) {
+    const seedHex = BSVUtils.toHex(Hash.sha256(idSeed, "utf8"));
+    base = base.derive(Utils.getSigningPathFromHex(seedHex));
+  }
+  return base.derive(rootPath).privKey;
+}
+
+function type42AccountKey(
+  pk: PrivateKey,
+  rootPath: string,
+  idSeed = ""
+): PrivateKey {
+  let base = pk;
+  if (idSeed) {
+    const seedHex = BSVUtils.toHex(Hash.sha256(idSeed, "utf8"));
+    base = base.deriveChild(base.toPublicKey(), seedHex);
+  }
+  return base.deriveChild(base.toPublicKey(), rootPath);
 }
 
 function freshType42(): { wif: string; pk: PrivateKey } {
@@ -103,6 +143,151 @@ describe("legacy export detection and recompute (Type 42)", () => {
     expect(recomputed[0].newBapId).not.toBe(entry.bapId);
     expect(recomputed[0].rootPath).toBe(ROOT_PATH);
     expect(bap.listIds()).toContain(expectedNewBapId);
+    expect(bap.getId(expectedNewBapId)?.export()).toMatchObject({
+      rootPath: ROOT_PATH,
+      previousPath: ROOT_PATH,
+      currentPath: ROOT_PATH,
+    });
+  });
+
+  test("preserves advanced Type 42 lineage, seed, account key, and root key exactly", () => {
+    const { wif, pk } = freshType42();
+    const idSeed = "legacy seed / keep byte-for-byte";
+    const rootPath = "bap:7";
+    const previousPath = "bap:7:3";
+    const currentPath = "bap:7:4";
+    const entry = makeLegacyType42Entry(pk, idSeed, {
+      rootPath,
+      previousPath,
+      currentPath,
+    });
+    const source = { lastIdPath: rootPath, ids: [entry] };
+    const sourceBytes = JSON.stringify(source);
+    const originalAccountWif = type42AccountKey(pk, rootPath, idSeed).toWif();
+
+    const bap = new BAP({ rootPk: wif });
+    expect(bap.isLegacyIdsExport(source)).toBe(true);
+    const [mapping] = bap.recomputeLegacyIds(source);
+    const restored = bap.getId(mapping.newBapId);
+
+    expect(mapping.oldBapId).toBe(entry.bapId);
+    expect(mapping.newBapId).not.toBe(entry.bapId);
+    expect(restored?.export()).toEqual({
+      bapId: mapping.newBapId,
+      rootPath,
+      rootAddress: deriveIdentity0Address(
+        type42AccountKey(pk, rootPath, idSeed)
+      ),
+      previousPath,
+      currentPath,
+      idSeed,
+      lastIdPath: "",
+    });
+    expect(restored?.rootAddress).not.toBe(entry.rootAddress);
+    expect(restored?.exportAccountBackup().wif).toBe(originalAccountWif);
+    expect(bap.exportIds(undefined, false).lastIdPath).toBe(rootPath);
+    expect(bap.exportForBackup()).toMatchObject({ rootPk: wif });
+    expect(JSON.stringify(source)).toBe(sourceBytes);
+
+    const reissuedIds = bap.exportIds(undefined, false);
+    const reloaded = new BAP({ rootPk: wif });
+    reloaded.importIds(reissuedIds, false);
+    expect(reloaded.getId(mapping.newBapId)?.export()).toEqual(
+      restored?.export()
+    );
+  });
+
+  test("preserves the historically supported numeric Type 42 lineage namespace", () => {
+    const { wif, pk } = freshType42();
+    const entry = makeLegacyType42Entry(pk, "", {
+      previousPath: "4",
+      currentPath: "5",
+    });
+    const bap = new BAP({ rootPk: wif });
+
+    const [mapping] = bap.recomputeLegacyIds({
+      lastIdPath: ROOT_PATH,
+      ids: [entry],
+    });
+    expect(bap.getId(mapping.newBapId)?.export()).toMatchObject({
+      rootPath: ROOT_PATH,
+      previousPath: "4",
+      currentPath: "5",
+    });
+  });
+
+  test("accepts the historical first numeric rotation for a nonzero identity index", () => {
+    const { wif, pk } = freshType42();
+    const rootPath = "bap:7";
+    const entry = makeLegacyType42Entry(pk, "", {
+      rootPath,
+      previousPath: rootPath,
+      currentPath: "8",
+    });
+    const bap = new BAP({ rootPk: wif });
+
+    const [mapping] = bap.recomputeLegacyIds({
+      lastIdPath: rootPath,
+      ids: [entry],
+    });
+    expect(bap.getId(mapping.newBapId)?.export()).toMatchObject({
+      rootPath,
+      previousPath: rootPath,
+      currentPath: "8",
+    });
+  });
+
+  test("accepts an advanced historical numeric lineage after its valid nonzero start", () => {
+    const { wif, pk } = freshType42();
+    const rootPath = "bap:7";
+    const entry = makeLegacyType42Entry(pk, "", {
+      rootPath,
+      previousPath: "10",
+      currentPath: "11",
+    });
+    const bap = new BAP({ rootPk: wif });
+
+    const [mapping] = bap.recomputeLegacyIds({
+      lastIdPath: rootPath,
+      ids: [entry],
+    });
+    expect(bap.getId(mapping.newBapId)?.export()).toMatchObject({
+      rootPath,
+      previousPath: "10",
+      currentPath: "11",
+    });
+  });
+
+  test("rejects numeric lineage before the historical start or with a skipped step", () => {
+    const { wif, pk } = freshType42();
+    const rootPath = "bap:7";
+    const invalidEntries = [
+      makeLegacyType42Entry(pk, "", {
+        rootPath,
+        previousPath: rootPath,
+        currentPath: "1",
+      }),
+      makeLegacyType42Entry(pk, "", {
+        rootPath,
+        previousPath: "7",
+        currentPath: "8",
+      }),
+      makeLegacyType42Entry(pk, "", {
+        rootPath,
+        previousPath: "8",
+        currentPath: "10",
+      }),
+    ];
+
+    for (const entry of invalidEntries) {
+      const bap = new BAP({ rootPk: wif });
+      const source = { lastIdPath: rootPath, ids: [entry] };
+      expect(bap.isLegacyIdsExport(source)).toBe(false);
+      expect(() => bap.recomputeLegacyIds(source)).toThrow(
+        "impossible Type 42 lineage"
+      );
+      expect(bap.listIds()).toEqual([]);
+    }
   });
 
   test("recomputes an encrypted legacy payload (string ids field)", () => {
@@ -140,6 +325,29 @@ describe("legacy export detection and recompute (Type 42)", () => {
     const recomputed = bap.recomputeLegacyIds(oldFormat);
     expect(recomputed).toHaveLength(1);
     expect(recomputed[0].oldBapId).toBe(entry.bapId);
+  });
+
+  test("the oldest array format may omit idSeed and preserves unrotated lineage", () => {
+    const { wif, pk } = freshType42();
+    const entry = makeLegacyType42Entry(pk);
+    const oldFormat = [
+      {
+        identityKey: entry.bapId,
+        rootPath: entry.rootPath,
+        rootAddress: entry.rootAddress,
+        currentPath: entry.currentPath,
+        previousPath: entry.previousPath,
+      },
+    ];
+
+    const bap = new BAP({ rootPk: wif });
+    const [mapping] = bap.recomputeLegacyIds(oldFormat);
+    expect(bap.getId(mapping.newBapId)?.export()).toMatchObject({
+      rootPath: ROOT_PATH,
+      previousPath: ROOT_PATH,
+      currentPath: ROOT_PATH,
+      idSeed: "",
+    });
   });
 
   test("handles idSeed entries (seeded legacy derivation)", () => {
@@ -183,6 +391,42 @@ describe("legacy export detection and recompute (Type 42)", () => {
       stranger.recomputeLegacyIds({ lastIdPath: ROOT_PATH, ids: [entry] })
     ).toThrow("ID does not belong to this private key");
   });
+
+  test("rejects tampered and malformed lineage without partially importing", () => {
+    const { wif, pk } = freshType42();
+    const valid = makeLegacyType42Entry(pk);
+    const skippedRotation = {
+      ...makeLegacyType42Entry(pk, "", {
+        previousPath: ROOT_PATH,
+        currentPath: "bap:0:1",
+      }),
+      currentPath: "bap:0:3",
+    };
+    const wrongNamespace = {
+      ...valid,
+      previousPath: "bap:9:1",
+      currentPath: "bap:9:2",
+    };
+    const tamperedBapId = { ...valid, bapId: `${valid.bapId}x` };
+    const missingPrevious = { ...valid } as Partial<typeof valid>;
+    delete missingPrevious.previousPath;
+
+    for (const invalid of [
+      skippedRotation,
+      wrongNamespace,
+      tamperedBapId,
+      missingPrevious,
+    ]) {
+      const bap = new BAP({ rootPk: wif });
+      const source = {
+        lastIdPath: ROOT_PATH,
+        ids: [valid, invalid],
+      };
+      expect(bap.isLegacyIdsExport(source as never)).toBe(false);
+      expect(() => bap.recomputeLegacyIds(source as never)).toThrow();
+      expect(bap.listIds()).toEqual([]);
+    }
+  });
 });
 
 describe("legacy export recompute (HD / xprv)", () => {
@@ -216,5 +460,86 @@ describe("legacy export recompute (HD / xprv)", () => {
     expect(recomputed).toHaveLength(1);
     expect(recomputed[0].newBapId).not.toBe(entry.bapId);
     expect(bap.listIds()).toContain(recomputed[0].newBapId);
+    expect(bap.getId(recomputed[0].newBapId)?.export()).toMatchObject({
+      rootPath,
+      previousPath: rootPath,
+      currentPath: rootPath,
+    });
+  });
+
+  test("preserves advanced HD lineage, seed, account key, xprv, and cursor exactly", () => {
+    const hd = HD.fromSeed(Mnemonic.fromRandom().toSeed());
+    const xprv = hd.toString();
+    const idSeed = "legacy-hd-seed";
+    const rootPath = "m/424150'/0'/0'/11/12/40";
+    const previousPath = "m/424150'/0'/0'/11/12/44";
+    const currentPath = "m/424150'/0'/0'/11/12/45";
+    const lastIdPath = "/11/12/40";
+    const rootAddress = legacyHdAddress(hd, rootPath, idSeed);
+    const entry = {
+      bapId: bapIdFromAddress(rootAddress),
+      rootPath,
+      rootAddress,
+      currentPath,
+      previousPath,
+      idSeed,
+      lastIdPath: "",
+    };
+    const source = { lastIdPath, ids: [entry] };
+    const sourceBytes = JSON.stringify(source);
+    const originalAccountWif = hdAccountKey(hd, rootPath, idSeed).toWif();
+
+    const bap = new BAP(xprv);
+    expect(bap.isLegacyIdsExport(source)).toBe(true);
+    const [mapping] = bap.recomputeLegacyIds(source);
+    const restored = bap.getId(mapping.newBapId);
+
+    expect(mapping.newBapId).not.toBe(mapping.oldBapId);
+    expect(restored?.export()).toEqual({
+      bapId: mapping.newBapId,
+      rootPath,
+      rootAddress: deriveIdentity0Address(hdAccountKey(hd, rootPath, idSeed)),
+      previousPath,
+      currentPath,
+      idSeed,
+      lastIdPath: "",
+    });
+    expect(restored?.rootAddress).not.toBe(rootAddress);
+    expect(restored?.exportAccountBackup().wif).toBe(originalAccountWif);
+    expect(bap.exportIds(undefined, false).lastIdPath).toBe(lastIdPath);
+    expect(bap.exportForBackup()).toMatchObject({ xprv });
+    expect(JSON.stringify(source)).toBe(sourceBytes);
+
+    const reissuedIds = bap.exportIds(undefined, false);
+    const reloaded = new BAP(xprv);
+    reloaded.importIds(reissuedIds, false);
+    expect(reloaded.getId(mapping.newBapId)?.export()).toEqual(
+      restored?.export()
+    );
+  });
+
+  test("rejects malformed or impossible HD lineage", () => {
+    const hd = HD.fromSeed(Mnemonic.fromRandom().toSeed());
+    const xprv = hd.toString();
+    const rootPath = "m/424150'/0'/0'/11/12/0";
+    const rootAddress = legacyHdAddress(hd, rootPath);
+    const entry = {
+      bapId: bapIdFromAddress(rootAddress),
+      rootPath,
+      rootAddress,
+      previousPath: "m/424150'/0'/0'/11/12/2",
+      currentPath: "m/424150'/0'/0'/11/12/4",
+      idSeed: "",
+      lastIdPath: "",
+    };
+    const bap = new BAP(xprv);
+
+    expect(
+      bap.isLegacyIdsExport({ lastIdPath: "/11/12/0", ids: [entry] })
+    ).toBe(false);
+    expect(() =>
+      bap.recomputeLegacyIds({ lastIdPath: "/11/12/0", ids: [entry] })
+    ).toThrow("impossible BIP32 lineage");
+    expect(bap.listIds()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- preserve xprv/rootPk, rootPath, idSeed, previousPath, and currentPath exactly during verified pre-0.3 metadata reissue
- recompute only BRC-100-aligned public rootAddress/BAP ID
- validate historical numeric and scoped Type42 lineage plus BIP32 lineage before atomic import
- fix seeded ownership checks and export/reimport compatibility

## Safety boundary
No rotation, key replacement, key-container conversion, network request, publication, wallet action, or Sigma account rebinding.

Legacy rotation fields were unsigned metadata, so this validates only locally provable structure; it does not claim cryptographic authenticity for those fields.

## Verification
- independent release review approved
- focused legacy suite: 18 passed, 0 failed
- TypeScript and Biome passed
- production package build passed
- xprv and Type42, seeded/unseeded, unrotated/advanced, old numeric/new scoped, atomic rejection, and export/reimport covered

Linear: OPL-4148