### PR TITLE
Release bsv-bap v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.3.5] - 2026-08-31
 
 ### Fixed
 - Legacy pre-0.3 metadata reissue now preserves validated `currentPath` and `previousPath` exactly for both Type 42 and BIP32/xprv backups instead of resetting advanced lineage through `newId()`. Reissue remains offline and key-preserving: only the BRC-100-aligned public `rootAddress`/`bapId` change. Malformed paths, impossible lineage transitions, and mismatched stored BAP IDs fail closed before any identity is imported.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsv-bap",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "BAP npm module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Releases the independently reviewed OPL-4148 lineage-preservation fix from PR #9.

- preserves xprv/rootPk and all stored lineage exactly
- recomputes only intentional BRC-100 public identity metadata
- no key rotation, conversion, publication, or network action
- package build, TypeScript, Biome, and 18 focused regressions passed