### PR TITLE
Release bsv-bap v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.6] - 2026-08-31
+
+### Fixed
+- Published tarballs now include the declared CommonJS bundle and source map. The CJS build targets Node, and the release gate packs and unpacks the package, verifies every declared export target, and smoke-loads the real `BAP` and `MasterID` APIs through both CommonJS and ESM.
+
 ## [0.3.5] - 2026-08-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsv-bap",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "BAP npm module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Releases the independently reviewed OPL-4149 package-export correction from PR #11.

- includes the Node-compatible CommonJS bundle and source map
- verifies all declared export targets from the actual packed tarball
- smoke-loads callable BAP and MasterID APIs through both require and import
- no key, identity, derivation, or lineage behavior changes